### PR TITLE
fix(line-break-shift): completed lin-break-shift logic

### DIFF
--- a/packages/common/line-break/src/createLineBreak.ts
+++ b/packages/common/line-break/src/createLineBreak.ts
@@ -5,6 +5,7 @@ import {
   getNodesByTypes,
   Transforms,
   WithElementType,
+  Text,
   Point,
 } from '@quadrats/core';
 import {
@@ -27,35 +28,54 @@ export function createLineBreak({
     type, text: variant ?? '', children: [{ text: '' }],
   });
 
-  const isSelectionInLineBreak: LineBreak['isSelectionInLineBreak'] = (editor, options = {}) => {
+  const isSelectionInLineBreak: LineBreak['isSelectionInLineBreak'] = (editor, options = {}, variant) => {
     const at: Point = editor?.selection?.focus ?? { offset: 15, path: [] };
     const start = at?.path?.[0] ?? 0;
 
     const [match] = getLineBreakNodes(editor, { at: [start], ...options });
-    return !!match && match[0].type === type;
+    return !!match && match[0].type === type && match[0].text === variant;
   };
+
+  const getCurrentAt = (editor: any): Point => (
+    editor?.selection?.focus ?? { offset: 15, path: [] }
+  );
+
   const toggleLineBreakNodes: LineBreak['toggleLineBreakNodes'] = (editor, variant) => {
-    const at: Point = editor?.selection?.focus ?? { offset: 15, path: [] };
+    const at: Point = getCurrentAt(editor);
     const isActive = isSelectionInLineBreak(editor, { at });
-
     const start = at?.path?.[0] ?? 0;
-    const end = 15; // slate 預設 end 最高為 15
 
-    if (isActive) {
-      Transforms.removeNodes(editor, {
-        at: [start],
-        match: (node) => node.type === type,
-      });
-    } else {
+    if (variant === LineBreakVariant.ENTER) {
+      if (isActive) {
+        Transforms.removeNodes(editor, {
+          at: [start],
+          match: (node) => node.type === type,
+        });
+      } else {
+        const lineBreak: LineBreakElement = createLineBreakElement(variant);
+
+        editor.insertBreak();
+        Transforms.insertNodes(editor, lineBreak, {
+          at: [start, 15],
+          match: (node) => Text.isText(node),
+          hanging: true,
+          voids: true,
+        });
+      }
+    }
+    if (variant === LineBreakVariant.SHIFT_ENTER) {
       const lineBreak: LineBreakElement = createLineBreakElement(variant);
 
-      editor.insertBreak();
-      Transforms.insertNodes(editor, lineBreak, {
-        at: [start, end],
-        match: (node) => node.type === 'p',
-        hanging: true,
-        voids: true,
-      });
+      /**
+       * @INFO 在 line-break icon 後面放一個 null tag
+       * 使得 selection 可以在同層級之間進行跳行的動作
+       * 否則無法跳行。
+      */
+      Transforms.insertNodes(editor, [
+        lineBreak,
+        { text: '\0' },
+      ], { at });
+      Transforms.move(editor, { distance: 2 });
     }
   };
 
@@ -65,7 +85,7 @@ export function createLineBreak({
     isSelectionInLineBreak,
     toggleLineBreakNodes,
     with(editor) {
-      const { isInline } = editor;
+      const { isInline, normalizeNode } = editor;
 
       editor.isInline = (element) => element.type === type || isInline(element);
 
@@ -78,6 +98,8 @@ export function createLineBreak({
            */
           normalizeVoidElementChildren(editor, [node, path]);
         }
+
+        normalizeNode(entry);
       };
 
       return editor;

--- a/packages/common/line-break/src/typings.ts
+++ b/packages/common/line-break/src/typings.ts
@@ -20,6 +20,6 @@ export enum LineBreakVariant {
 
 export interface LineBreak extends WithElementType, Withable {
   getLineBreakNodes(editor: Editor, options?: GetNodesOptions): Generator<NodeEntry<Node>>;
-  isSelectionInLineBreak(editor: Editor, options?: GetNodesOptions): boolean;
+  isSelectionInLineBreak(editor: Editor, options?: GetNodesOptions, variant?: LineBreakVariant): boolean;
   toggleLineBreakNodes(editor: Editor, variant?: LineBreakVariant): void;
 }

--- a/packages/react/line-break/src/components/LineBreakIcon.tsx
+++ b/packages/react/line-break/src/components/LineBreakIcon.tsx
@@ -9,24 +9,31 @@ function LineBreakIcon({
 }: ReactLineBreakIconElementProps) {
   const ref = useRef<HTMLSpanElement | null>(null);
 
+  const isShiftEnter = useMemo(() => (
+    element.text === 'shift-enter'
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), []);
+
   const icon = useMemo(() => {
-    if (element.text === 'shift-enter') return LineBreakShiftEnter;
+    if (isShiftEnter) return LineBreakShiftEnter;
 
     return LineBreakEnter;
-  }, [element.text]);
+  }, [isShiftEnter]);
 
   useEffect(() => {
-    if (element.text !== 'shift-enter') return;
-
     const paragraphElement = ref.current?.parentElement;
 
-    if (paragraphElement) {
+    if (isShiftEnter && paragraphElement) {
       paragraphElement.setAttribute(
         'style',
         'margin-inline: 0; margin-block: 0;',
       );
     }
-  }, [element.text]);
+
+    if (!isShiftEnter && paragraphElement) {
+      paragraphElement.removeAttribute('style');
+    }
+  }, [isShiftEnter]);
 
   return (
     <span

--- a/packages/react/line-break/src/components/LineBreakIcon.tsx
+++ b/packages/react/line-break/src/components/LineBreakIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect, useMemo } from 'react';
 import { LineBreakEnter, LineBreakShiftEnter } from '@quadrats/icons';
 import { Icon } from '@quadrats/react/components';
 import { ReactLineBreakIconElementProps } from '../typings';
@@ -7,24 +7,48 @@ function LineBreakIcon({
   attributes,
   element,
 }: ReactLineBreakIconElementProps) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+
+  const icon = useMemo(() => {
+    if (element.text === 'shift-enter') return LineBreakShiftEnter;
+
+    return LineBreakEnter;
+  }, [element.text]);
+
+  useEffect(() => {
+    if (element.text !== 'shift-enter') return;
+
+    const paragraphElement = ref.current?.parentElement;
+
+    if (paragraphElement) {
+      paragraphElement.setAttribute(
+        'style',
+        'margin-inline: 0; margin-block: 0;',
+      );
+    }
+  }, [element.text]);
+
   return (
     <span
       {...attributes}
+      ref={ref}
       contentEditable={false}
       style={{
+        marginBlock: 0,
+        marginInline: 0,
         userSelect: 'none',
-        verticalAlign: 'middle',
       }}
     >
       <Icon
         style={{
           width: '24px',
           height: '24px',
-          paddingTop: element.text === 'enter' ? '1px' : '6px',
+          verticalAlign: 'middle',
         }}
-        icon={element.text === 'enter' ? LineBreakEnter : LineBreakShiftEnter}
+        icon={icon}
         color="#C1C1C1"
       />
+      <br />
     </span>
   );
 }

--- a/packages/react/line-break/src/createReactLineBreak.ts
+++ b/packages/react/line-break/src/createReactLineBreak.ts
@@ -34,7 +34,8 @@ export function createReactLineBreak(
 
       return {
         onKeyDown(event, editor, next) {
-          const isActive = core.isSelectionInLineBreak(editor);
+          const lineBreakAlreadyExist = core.isSelectionInLineBreak(editor, {}, LineBreakVariant.ENTER);
+
           /**
            * Only toggle if the hotkey is fired and the key is the same as level.
            */
@@ -54,23 +55,29 @@ export function createReactLineBreak(
             } catch {}
           } else if (
             isHotkey(LINE_BREAK_INITIAL_HOT_KEYS, event as any)
-            && isActive
+            && lineBreakAlreadyExist
           ) {
-            const start = editor.selection?.focus?.path?.[0] ?? 0;
-
-            Transforms.removeNodes(editor, {
-              at: [start],
-              match: (node) => node.type === type,
-            });
-          } else {
-            if (isActive) {
+            try {
               const start = editor.selection?.focus?.path?.[0] ?? 0;
 
-              Transforms.moveNodes(editor, {
+              Transforms.removeNodes(editor, {
                 at: [start],
-                to: [start, 15],
                 match: (node) => node.type === type,
               });
+              // eslint-disable-next-line no-empty
+            } catch {}
+          } else {
+            if (lineBreakAlreadyExist) {
+              try {
+                const start = editor.selection?.focus?.path?.[0] ?? 0;
+
+                Transforms.moveNodes(editor, {
+                  at: [start],
+                  to: [start, 15],
+                  match: (node) => node.type === type,
+                });
+                // eslint-disable-next-line no-empty
+              } catch {}
             }
 
             onKeyDownBreak(event, editor, next);


### PR DESCRIPTION
1. 完成 `line-break: shift+enter` 邏輯及顯示。
2. 修正 icon 高度影響 line-height 問題。

- ![截圖 2021-11-29 下午11 16 23](https://user-images.githubusercontent.com/68156396/143917571-c090ba55-80d1-441b-9e9a-3c96c9fcc362.png)
- ![截圖 2021-11-29 下午11 16 49](https://user-images.githubusercontent.com/68156396/143917580-3fdf31e3-9540-49a8-8829-a7fb00b41cb0.png)
- ![截圖 2021-11-30 上午1 21 55](https://user-images.githubusercontent.com/68156396/143917586-fa34a489-01d5-4b17-bf94-2eae095937f6.png)
- ![截圖 2021-11-30 上午1 22 22](https://user-images.githubusercontent.com/68156396/143917588-1c6fa61d-3b7f-4611-a840-6d53a58172d9.png)
- ![截圖 2021-11-30 上午1 31 10](https://user-images.githubusercontent.com/68156396/143917590-e188061f-f605-409d-945b-cfdfad7f7cbe.png)
- ![截圖 2021-11-30 上午2 07 46](https://user-images.githubusercontent.com/68156396/143920511-3feded2a-f8ba-4eea-be36-abf100e87802.png)

