### PR TITLE
fix: line-break null child issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.format.enable": true
+  "eslint.format.enable": true,
+  "cSpell.words": ["Quadrats"]
 }

--- a/packages/core/src/line-break/createLineBreak.ts
+++ b/packages/core/src/line-break/createLineBreak.ts
@@ -1,10 +1,8 @@
-/* eslint-disable no-useless-return */
-import { Element } from 'slate';
+import { Element, Transforms } from 'slate';
 import { LineBreak } from './typings';
 import { LINE_BREAK_TYPE } from './constants';
 import { WithElementType } from '../adapter/slate';
-import { normalizeVoidElementChildren } from '../normalizers/normalizeVoidElementChildren';
-import { QuadratsElement } from '../typings';
+import { QuadratsElement, QuadratsText } from '../typings';
 
 export type CreateLineBreakOptions = Partial<WithElementType>;
 
@@ -22,13 +20,29 @@ export function createLineBreak({
         const [node, path] = entry;
 
         if (Element.isElement(node) && (node as QuadratsElement).type === type) {
-          /**
-           * Set invalid level elements to default.
-           */
-          normalizeVoidElementChildren(editor, [node as QuadratsElement, path]);
-        }
+          // move out children if something inserted in the line-break node
+          // line-break children is only allow '\n' text
+          // other node or text should be move out
+          node.children?.forEach((child, index) => {
+            const element = child as QuadratsElement;
 
-        normalizeNode(entry);
+            if (element?.type || (child as QuadratsText)?.text !== '\n') {
+              const moveto = path.slice();
+
+              moveto[(path.length - 1)] += 1;
+
+              Transforms.moveNodes(editor, { at: path.concat(index), to: moveto });
+            }
+          });
+
+          // remove LineBreak node if children text '\n' has been removed
+          if (node.children.length === 1 && ((node.children?.[0] as QuadratsText)?.text === '')
+            || node.children.length < 1) {
+            Transforms.removeNodes(editor, { at: path });
+          }
+        } else {
+          normalizeNode(entry);
+        }
       };
 
       return editor;

--- a/packages/core/src/transforms/insertSoftBreak.ts
+++ b/packages/core/src/transforms/insertSoftBreak.ts
@@ -1,32 +1,9 @@
-import { Editor, Transforms } from 'slate';
+import { Editor } from 'slate';
 import { LINE_BREAK_TYPE } from '../line-break';
 import { QuadratsElement } from '../typings';
 
 export function insertSoftBreak(editor: Editor) {
-  let originPath;
+  const softBreakElement: QuadratsElement = { type: LINE_BREAK_TYPE, children: [{ text: '\n' }] };
 
-  if (editor.selection) {
-    originPath = editor.selection.focus.path;
-  }
-
-  editor.insertNode({ type: LINE_BREAK_TYPE, children: [{ text: '\n' }] } as QuadratsElement);
-
-  if (originPath) {
-    Transforms.select(editor, {
-      anchor: {
-        offset: 0,
-        path: [
-          ...originPath.slice(0, -1),
-          originPath[originPath.length - 1] + 2,
-        ],
-      },
-      focus: {
-        offset: 0,
-        path: [
-          ...originPath.slice(0, -1),
-          originPath[originPath.length - 1] + 2,
-        ],
-      },
-    });
-  }
+  editor.insertNode(softBreakElement);
 }

--- a/packages/react/line-break/src/defaultRenderLineBreakElement.tsx
+++ b/packages/react/line-break/src/defaultRenderLineBreakElement.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { RenderLineBreakElementProps } from './typings';
 
-export const defaultRenderLineBreakElement = ({ attributes }: RenderLineBreakElementProps) => (
-  <span {...attributes} style={{ userSelect: 'none' }} contentEditable={false}>
-    <br />
+export const defaultRenderLineBreakElement = ({ attributes, children }: RenderLineBreakElementProps) => (
+  <span {...attributes} className="qdr-line-break">
+    {children}
   </span>
 );

--- a/packages/react/line-break/src/renderLineBreakElementWithSymbol.tsx
+++ b/packages/react/line-break/src/renderLineBreakElementWithSymbol.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { RenderLineBreakElementProps } from './typings';
 
-export const renderLineBreakElementWithSymbol = ({ attributes }: RenderLineBreakElementProps) => (
-  <span {...attributes} style={{ userSelect: 'none' }} className="qdr-line-break__with-symbol" contentEditable={false}>
-    <br />
+export const renderLineBreakElementWithSymbol = ({ attributes, children }: RenderLineBreakElementProps) => (
+  <span {...attributes} className="qdr-line-break qdr-line-break__with-symbol">
+    {children}
   </span>
 );


### PR DESCRIPTION
- 修復多行 line-break 向前選擇會指向不存在的 node 導致 crash 的問題
- 修復多行 line-break 之間移動游標時直接跳過所有 line-break 選擇至段落首或段落底的問題

已知衍伸 issue:
- 由後往前選擇 line-break 時會指向其 children, 此時若再次新增 line-break 游標會多往後跳一行 