### PR TITLE
feat: add className to all plugins

### DIFF
--- a/packages/react/blockquote/src/defaultRenderBlockquoteElement.tsx
+++ b/packages/react/blockquote/src/defaultRenderBlockquoteElement.tsx
@@ -7,4 +7,4 @@ export const defaultRenderBlockquoteElement = ({
 }: {
   attributes?: RenderElementProps['attributes'];
   children: RenderElementProps['children'];
-}) => <blockquote {...attributes}>{children}</blockquote>;
+}) => <blockquote {...attributes} className="qdr-blockquote">{children}</blockquote>;

--- a/packages/react/divider/src/defaultRenderDividerElement.tsx
+++ b/packages/react/divider/src/defaultRenderDividerElement.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { RenderDividerElementProps } from './typings';
 
 export const defaultRenderDividerElement = ({ attributes, children }: RenderDividerElementProps) => (
-  <div {...attributes} contentEditable={false}>
+  <div {...attributes} className="qdr-divider" contentEditable={false}>
     <hr />
     {children}
   </div>

--- a/packages/react/embed/renderers/facebook/src/components/Facebook.tsx
+++ b/packages/react/embed/renderers/facebook/src/components/Facebook.tsx
@@ -11,7 +11,7 @@ export interface FacebookProps {
 
 function Facebook({ attributes, children, data: { url, width, height } }: FacebookProps) {
   return (
-    <div {...attributes} contentEditable={false}>
+    <div {...attributes} className="qdr-embed-facebook" contentEditable={false}>
       <iframe
         title={url}
         src={url}

--- a/packages/react/embed/renderers/instagram/src/components/Instagram.tsx
+++ b/packages/react/embed/renderers/instagram/src/components/Instagram.tsx
@@ -16,6 +16,7 @@ function Instagram({ attributes, children, data: permalink }: InstagramProps) {
   return (
     <div
       {...attributes}
+      className="qdr-embed-instagram"
       contentEditable={false}
       style={{
         display: 'flex',

--- a/packages/react/embed/renderers/podcast-apple/src/components/PodcastApple.tsx
+++ b/packages/react/embed/renderers/podcast-apple/src/components/PodcastApple.tsx
@@ -1,21 +1,25 @@
-import React, { useRef } from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
 import { PodcastAppleEmbedElement } from '@quadrats/common/embed/strategies/podcast-apple';
 import { RenderElementProps } from '@quadrats/react';
 import { composeRefs } from '@quadrats/react/utils';
 
 export interface PodcastAppleProps {
   attributes?: RenderElementProps['attributes'];
-  children?: any;
   data: string;
   element: PodcastAppleEmbedElement;
 }
 
-function PodcastApple({ attributes, children, data: src }: PodcastAppleProps) {
+function PodcastApple({ attributes, children, data: src }: PropsWithChildren<PodcastAppleProps>) {
   const containerRef = useRef<HTMLElement | null>(null);
   const composedRef = composeRefs([attributes?.ref, containerRef]);
 
   return (
-    <div {...attributes} ref={composedRef} contentEditable={false}>
+    <div
+      {...attributes}
+      className="qdr-embed-podcast-apple"
+      ref={composedRef}
+      contentEditable={false}
+    >
       <iframe
         title={src}
         src={src}

--- a/packages/react/embed/renderers/spotify/src/components/Spotify.tsx
+++ b/packages/react/embed/renderers/spotify/src/components/Spotify.tsx
@@ -22,6 +22,7 @@ function Spotify({ attributes, children, data: src }: SpotifyProps) {
     <div
       {...attributes}
       ref={composedRef}
+      className="qdr-embed-spotify"
       contentEditable={false}
     >
       <iframe

--- a/packages/react/embed/renderers/twitter/src/components/Twitter.tsx
+++ b/packages/react/embed/renderers/twitter/src/components/Twitter.tsx
@@ -21,6 +21,7 @@ function Twitter({ attributes, children, data: tweetId }: TwitterProps) {
     <div
       {...attributes}
       ref={composedRef}
+      className="qdr-embed-twitter"
       contentEditable={false}
     >
       {attributes ? children : undefined}

--- a/packages/react/embed/src/components/VideoIframe.tsx
+++ b/packages/react/embed/src/components/VideoIframe.tsx
@@ -11,13 +11,22 @@ export interface VideoIframeProps<E extends EmbedElement> {
   element: E;
 }
 
-function VideoIframe<E extends EmbedElement>({ attributes, children, data: src }: VideoIframeProps<E>) {
+function VideoIframe<E extends EmbedElement>({
+  attributes,
+  children,
+  data: src,
+}: VideoIframeProps<E>) {
   const { ref } = attributes || {};
   const { ref: containerRef, size } = useVideoIframeSize<HTMLDivElement>();
   const composedRef = ref ? composeRefs([ref, containerRef]) : containerRef;
 
   return (
-    <div {...attributes} ref={composedRef} contentEditable={false}>
+    <div
+      {...attributes}
+      ref={composedRef}
+      className="qdr-embed-video"
+      contentEditable={false}
+    >
       <div style={size}>
         <iframe title={src} src={src} frameBorder="0" width="100%" height="100%" />
       </div>

--- a/packages/react/footnote/src/defaultRenderFootnoteElement.tsx
+++ b/packages/react/footnote/src/defaultRenderFootnoteElement.tsx
@@ -19,12 +19,13 @@ export const defaultRenderFootnoteElement = ({
   return (
     <>
       <Tooltip placement={placement} popup={footnote}>
-        <span style={{ textDecoration: 'underline' }} {...attributes}>
+        <span style={{ textDecoration: 'underline' }} {...attributes} className="qdr-footnote-text">
           {children}
         </span>
       </Tooltip>
       <sup
         {...attributes}
+        className="qdr-footnote-sup"
         style={{ color: 'var(--qdr-sup)', userSelect: 'none' }}
         contentEditable={false}
       >

--- a/packages/react/heading/src/defaultRenderHeadingElement.tsx
+++ b/packages/react/heading/src/defaultRenderHeadingElement.tsx
@@ -26,5 +26,5 @@ export const defaultRenderHeadingElement = ({
     return null;
   }
 
-  return <Component {...attributes}>{children}</Component>;
+  return <Component {...attributes} className={`qdr-${Component}`}>{children}</Component>;
 };

--- a/packages/react/input-block/src/components/InputBlock.tsx
+++ b/packages/react/input-block/src/components/InputBlock.tsx
@@ -15,6 +15,7 @@ function InputBlock(props: RenderInputBlockElementProps) {
       style={{
         display: 'flex',
       }}
+      className="qdr-input-block"
     >
       <input
         ref={inputRef}

--- a/packages/react/link/src/defaultRenderLinkElement.tsx
+++ b/packages/react/link/src/defaultRenderLinkElement.tsx
@@ -19,7 +19,7 @@ export const defaultRenderLinkElement = ({
 
   return (
     <Tooltip placement={placement} popup={url}>
-      <a {...attributes} href={url} target={target}>
+      <a {...attributes} className="qdr-link" href={url} target={target}>
         {children}
       </a>
     </Tooltip>

--- a/packages/react/list/src/defaultRenderListElements.tsx
+++ b/packages/react/list/src/defaultRenderListElements.tsx
@@ -6,7 +6,7 @@ export const defaultRenderListElements: Record<
 ListTypeKey,
 (props: { attributes?: RenderElementProps['attributes']; children: any }) => JSX.Element
 > = {
-  ol: ({ attributes, children }) => <ol {...attributes}>{children}</ol>,
-  ul: ({ attributes, children }) => <ul {...attributes}>{children}</ul>,
-  li: ({ attributes, children }) => <li {...attributes}>{children}</li>,
+  ol: ({ attributes, children }) => <ol {...attributes} className="qdr-ol">{children}</ol>,
+  ul: ({ attributes, children }) => <ul {...attributes} className="qdr-ul">{children}</ul>,
+  li: ({ attributes, children }) => <li {...attributes} className="qdr-li">{children}</li>,
 };

--- a/packages/react/paragraph/src/defaultRenderParagraphElement.tsx
+++ b/packages/react/paragraph/src/defaultRenderParagraphElement.tsx
@@ -8,7 +8,7 @@ export const defaultRenderParagraphElement = ({
   attributes?: RenderElementProps['attributes'];
   children: any;
 }) => (
-  <p {...attributes}>
+  <p {...attributes} className="qdr-paragraph">
     {children}
   </p>
 );

--- a/packages/react/paragraph/src/renderParagraphElementWithSymbol.tsx
+++ b/packages/react/paragraph/src/renderParagraphElementWithSymbol.tsx
@@ -8,7 +8,7 @@ export const renderParagraphElementWithSymbol = ({
   attributes?: RenderElementProps['attributes'];
   children: any;
 }) => (
-  <p {...attributes} className="qdr-paragraph__with-line-break-symbol">
+  <p {...attributes} className="qdr-paragraph qdr-paragraph__with-line-break-symbol">
     {children}
   </p>
 );

--- a/stories/elements/embed/embed.stories.tsx
+++ b/stories/elements/embed/embed.stories.tsx
@@ -50,6 +50,7 @@ export const Example = ({ type }: { type: string }) => {
       spotify: SpotifyEmbedStrategy,
     },
   });
+
   const renderElement = composeRenderElements([
     embed.createRenderElement({
       youtube: defaultRenderYoutubeEmbedElement,
@@ -61,6 +62,7 @@ export const Example = ({ type }: { type: string }) => {
       spotify: defaultRenderTwitterEmbedElement,
     }),
   ]);
+
   const initialValues: Descendant[] = [
     {
       type: PARAGRAPH_TYPE,
@@ -93,37 +95,37 @@ export const Example = ({ type }: { type: string }) => {
                 icon={VideoIcon}
                 controller={embed}
                 providers={['youtube', 'vimeo']}
-                getPlaceholder={(locale) => locale.editor.video.inputPlaceholder}
+                getPlaceholder={locale => locale.editor.video.inputPlaceholder}
               />
               <EmbedToolbarIcon
                 icon={InstagramIcon}
                 controller={embed}
                 providers={['instagram']}
-                getPlaceholder={(locale) => locale.editor.instagram.inputPlaceholder}
+                getPlaceholder={locale => locale.editor.instagram.inputPlaceholder}
               />
               <EmbedToolbarIcon
                 icon={FacebookIcon}
                 controller={embed}
                 providers={['facebook']}
-                getPlaceholder={(locale) => locale.editor.facebook.inputPlaceholder}
+                getPlaceholder={locale => locale.editor.facebook.inputPlaceholder}
               />
               <EmbedToolbarIcon
                 icon={TwitterIcon}
                 controller={embed}
                 providers={['twitter']}
-                getPlaceholder={(locale) => locale.editor.twitter.tweet.inputPlaceholder}
+                getPlaceholder={locale => locale.editor.twitter.tweet.inputPlaceholder}
               />
               <EmbedToolbarIcon
                 icon={PodcastAppleIcon}
                 controller={embed}
                 providers={['podcastApple']}
-                getPlaceholder={(locale) => locale.editor.podcastApple.inputPlaceholder}
+                getPlaceholder={locale => locale.editor.podcastApple.inputPlaceholder}
               />
               <EmbedToolbarIcon
                 icon={SpotifyIcon}
                 controller={embed}
                 providers={['spotify']}
-                getPlaceholder={(locale) => locale.editor.spotify.inputPlaceholder}
+                getPlaceholder={locale => locale.editor.spotify.inputPlaceholder}
               />
             </>
           )}


### PR DESCRIPTION
對插件預設的 Render function 所輸出的最外層 element 加上 className

```
qdr-paragraph
qdr-paragraph__with-line-break-symbol

qdr-line-break
qdr-line-break__with-symbol

qdr-h1
qdr-h2
qdr-h3
qdr-h4
qdr-h5
qdr-h6

qdr-ol
qdr-ul
qdr-li

qdr-link

qdr-footnote-text
qdr-footnote-sup

qdr-embed-video ( youtube, vimeo )
qdr-embed-instagram
qdr-embed-facebook
qdr-embed-twitter
qdr-embed-podcast-apple
qdr-embed-spotify

qdr-image
qdr-image__figure
qdr-image__caption

qdr-blockquote
qdr-divider
qdr-file-uploader
qdr-input-block
qdr-read-more
```