### PR TITLE
fix(utils): correct isImageUrl regex

### DIFF
--- a/packages/utils/src/isImageUrl.ts
+++ b/packages/utils/src/isImageUrl.ts
@@ -125,7 +125,11 @@ const imageExtensions = [
 
 const imageExtensionsOr = imageExtensions.join('|');
 const dataUrlRegex = new RegExp(`^data:image/(${imageExtensionsOr}).*`);
-const imageUrlRegex = new RegExp(`.*.(${imageExtensionsOr})$`);
+/**
+ * \. is necessary escape for image url regex, so disabled eslint rule.
+ */
+// eslint-disable-next-line no-useless-escape
+const imageUrlRegex = new RegExp(`/.*\.(?:${imageExtensionsOr})$/`);
 
 export function isImageUrl(url: string) {
   return dataUrlRegex.test(url) || (isUrl(url) && imageUrlRegex.test(url));


### PR DESCRIPTION
附上原本判斷式：
原本應是為了判斷 url 結尾是否為 `.jpg, .png ... etc` 這類的檔名結尾，但漏寫了部分規則，導致字串中只要出現相關的字就會被判定為圖片
比如此連結中有 "ai"：https://www.mckinsey.com/featured-insights/mckinsey-explainers/what-is-generative-ai
```js
.*.(ase|art|bmp|blp|cd5|cit|cpt|cr2|cut|dds|dib|djvu|egt|exif|gif|gpl|grf|icns|ico|iff|jng|jpeg|jpg|jfif|jp2|jps|lbm|max|miff|mng|msp|nitf|ota|pbm|pc1|pc2|pc3|pcf|pcx|pdn|pgm|PI1|PI2|PI3|pict|pct|pnm|pns|ppm|psb|psd|pdd|psp|px|pxm|pxr|qfx|raw|rle|sct|sgi|rgb|int|bw|tga|tiff|tif|vtf|xbm|xcf|xpm|3dv|amf|ai|awg|cgm|cdr|cmx|dxf|e2d|egt|eps|fs|gbr|odg|svg|stl|vrml|x3d|sxd|v2d|vnd|wmf|emf|art|xar|png|webp|jxr|hdp|wdp|cur|ecw|iff|lbm|liff|nrrd|pam|pcx|pgf|sgi|rgb|rgba|bw|int|inta|sid|ras|sun|tga)$
```

新的判斷式：
```js
/.*\.(?:ase|art|bmp|blp|cd5|cit|cpt|cr2|cut|dds|dib|djvu|egt|exif|gif|gpl|grf|icns|ico|iff|jng|jpeg|jpg|jfif|jp2|jps|lbm|max|miff|mng|msp|nitf|ota|pbm|pc1|pc2|pc3|pcf|pcx|pdn|pgm|PI1|PI2|PI3|pict|pct|pnm|pns|ppm|psb|psd|pdd|psp|px|pxm|pxr|qfx|raw|rle|sct|sgi|rgb|int|bw|tga|tiff|tif|vtf|xbm|xcf|xpm|3dv|amf|ai|awg|cgm|cdr|cmx|dxf|e2d|egt|eps|fs|gbr|odg|svg|stl|vrml|x3d|sxd|v2d|vnd|wmf|emf|art|xar|png|webp|jxr|hdp|wdp|cur|ecw|iff|lbm|liff|nrrd|pam|pcx|pgf|sgi|rgb|rgba|bw|int|inta|sid|ras|sun|tga)$/
```