### PR TITLE
fix(toolbar): allow toolbar to wrap and grow instead of fixed height

### DIFF
--- a/packages/react/toolbar/src/components/toolbar.scss
+++ b/packages/react/toolbar/src/components/toolbar.scss
@@ -8,8 +8,10 @@ $qdr-toolbar-input-cross-size: --qdr-spacing-7;
 .qdr-toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--qdr-spacing-4);
-  height: var(#{$qdr-toolbar-height});
+  min-height: var(#{$qdr-toolbar-height});
+  height: auto;
   padding: var(#{$qdr-toolbar-padding-vertical}) var(#{$qdr-toolbar-padding-horizontal});
   background-color: var(--qdr-surface);
   border: 1px solid var(--qdr-border);
@@ -56,7 +58,8 @@ $qdr-toolbar-input-cross-size: --qdr-spacing-7;
 
   &__wrapper {
     box-sizing: content-box;
-    height: var(#{$qdr-toolbar-height});
+    min-height: var(#{$qdr-toolbar-height});
+    height: auto;
 
     &--fixed {
       position: sticky;


### PR DESCRIPTION
# fix(toolbar): allow toolbar to wrap and grow instead of fixed height

> Branch: `fix/q1-toolbar-height`（commit `ca29dbf`）
> 影響套件：`@quadrats/react`（toolbar 樣式 `toolbar.css` / `toolbar.scss`）

## 問題

`.qdr-toolbar` 與 `.qdr-toolbar__wrapper` 都被釘死在固定高度 `var(--qdr-spacing-14)`（48px），而 `.qdr-toolbar` 是 flex container、預設 `flex-wrap: nowrap`。當編輯器欄位變窄（常見於後台兩欄版型、RWD、側欄表單）時，固定 toolbar 必壞，且依 host 樣式不同有兩種病徵：

1. **水平裁切（host 未設 wrap）**：14 顆工具不換行、向右溢出，被編輯器外框 `overflow: hidden` 裁掉 → 尾端工具（連結、UL/OL、分隔線…）完全點不到、無法插入元素。
2. **換行蓋頂（host 自行設 `flex-wrap: wrap`）**：toolbar 內容長高，但 `__wrapper` 仍固定 48px → 第二行工具直接蓋住編輯區頂端 → 第一行內文點不到、打不出字。

## 重現

- 病徵 1（水平裁切）：把含 `<Toolbar fixed>` 的 RichEditor 放進寬度 ≤768px 的容器（例如 Next.js 後台兩欄表單），啟用 14 顆工具。768px 失去 UL/OL/連結/分隔線；640px 失去 U 以後全部。
- 病徵 2（蓋頂）：host CSS 對 `.qdr-toolbar` 加 `flex-wrap: wrap`（試圖自救）→ wrapper 固定高不動，第二行工具覆蓋 editable 頂端，`elementFromPoint` 驗證頂部座標命中 toolbar 而非編輯區。

## 根因

`packages/react/toolbar/src/components/toolbar.scss`：

- `.qdr-toolbar { height: var(--qdr-spacing-14); }`（固定高）＋ flex 預設 `nowrap`
- `.qdr-toolbar__wrapper { height: var(--qdr-spacing-14); }`（固定高，sticky 容器）

固定高 + nowrap 是同一個根因，兩種病徵只是 host 有沒有自設 wrap 的差別。

## 修法（diff 摘要）

```diff
 .qdr-toolbar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--qdr-spacing-4);
-  height: var(#{$qdr-toolbar-height});
+  min-height: var(#{$qdr-toolbar-height});
+  height: auto;
   padding: ...;

   &__wrapper {
     box-sizing: content-box;
-    height: var(#{$qdr-toolbar-height});
+    min-height: var(#{$qdr-toolbar-height});
+    height: auto;
```

單行情境維持現在的 48px 外觀（min-height 撐住）；多行時 toolbar 與 wrapper 一起自然長高，不裁切、不蓋頂。

## 影響面

- 只動 toolbar 佈局兩個 class；寬容器（單行）下視覺零變化。
- float（選字 bubble）toolbar 為 shrink-to-fit 絕對定位，不受 min-height/wrap 影響（同樣式已在下游 app 以 dist-patch 全量驗證）。
- 上游修好後，downstream apps can drop their workarounds：patch-package overrides、手動 wrap CSS、hand-rolled static toolbars。

## 驗證證據

- **repo 端**：`npx sass packages/react/toolbar/src/components/toolbar.scss --style=compressed` 編譯產物與下游 app 實戰驗證過的 patch-package dist patch（`@quadrats/react@1.1.11`）after 內容 **byte-identical**（diff 為空）。`npx stylelint` 通過。
- **實戰驗證**：verified in a production CMS admin（@mezzanine-ui/react 1.3.0 + @quadrats/react 1.1.11）：同內容 dist-patch 後 640/768/1024/1440 四寬度 0 裁切、工具自動換行、wrapper 隨內容長高、無蓋頂（overlap 0px）、頂部 {x:30,y:10} 打字 OK、640px 點分隔線成功插入（repro 腳本 RESULT=PASS）。前後截圖與量測 JSON 可應 reviewer 要求提供（before/after screenshots and measurement JSON available on request）。
- **交叉驗證**：cross-checked in three other downstream apps exhibiting both symptoms——一例 wrap 蓋頂病徵、一例自刻 static toolbar workaround（同根因）、一例以 `elementFromPoint` 驗證 toolbar 不蓋頂。

## 備註

- 一坑一 PR：本 PR 只動 toolbar 高度/換行，不含其他樣式調整。
- repo 測試基線（清 clone @ bb573c9）：jest 7 suites 中 2 個 blockquote suite 先天紅（fixture TS2322 + 缺 jest-environment-jsdom），與本 PR 無關；本 PR 不含 TS/測試變更。
