### PR TITLE
fix(configs): inherit ancestor configs in nested ConfigsProvider

### DIFF
--- a/packages/react/configs/src/ConfigsProvider.spec.tsx
+++ b/packages/react/configs/src/ConfigsProvider.spec.tsx
@@ -1,0 +1,101 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { enUS, LocaleDefinition, zhTW } from '@quadrats/locales';
+import ConfigsProvider from './ConfigsProvider';
+import { useLocale } from './locale';
+import { useTheme } from './theme';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  act(() => {
+    root.unmount();
+  });
+}
+
+describe('ConfigsProvider', () => {
+  it('should provide enUS by default at top level', () => {
+    let captured: LocaleDefinition | undefined;
+
+    function Probe() {
+      captured = useLocale();
+
+      return null;
+    }
+
+    render(
+      <ConfigsProvider>
+        <Probe />
+      </ConfigsProvider>,
+    );
+
+    expect(captured).toBe(enUS);
+  });
+
+  it('should inherit locale from ancestor provider when omitted', () => {
+    let captured: LocaleDefinition | undefined;
+
+    function Probe() {
+      captured = useLocale();
+
+      return null;
+    }
+
+    render(
+      <ConfigsProvider locale={zhTW}>
+        <ConfigsProvider>
+          <Probe />
+        </ConfigsProvider>
+      </ConfigsProvider>,
+    );
+
+    expect(captured).toBe(zhTW);
+  });
+
+  it('should let explicit locale on nested provider win over ancestor', () => {
+    let captured: LocaleDefinition | undefined;
+
+    function Probe() {
+      captured = useLocale();
+
+      return null;
+    }
+
+    render(
+      <ConfigsProvider locale={zhTW}>
+        <ConfigsProvider locale={enUS}>
+          <Probe />
+        </ConfigsProvider>
+      </ConfigsProvider>,
+    );
+
+    expect(captured).toBe(enUS);
+  });
+
+  it('should inherit theme from ancestor provider when omitted', () => {
+    let captured: string | undefined;
+
+    function Probe() {
+      captured = useTheme().props.className;
+
+      return null;
+    }
+
+    render(
+      <ConfigsProvider theme="custom">
+        <ConfigsProvider>
+          <Probe />
+        </ConfigsProvider>
+      </ConfigsProvider>,
+    );
+
+    expect(captured).toBe('qdr-theme-custom');
+  });
+});

--- a/packages/react/configs/src/ConfigsProvider.tsx
+++ b/packages/react/configs/src/ConfigsProvider.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode, useMemo } from 'react';
+import React, { ReactNode, useContext, useMemo } from 'react';
 import { Theme } from '@quadrats/theme';
-import { enUS, LocaleDefinition } from '@quadrats/locales';
+import { LocaleDefinition } from '@quadrats/locales';
 import { LocaleContext } from './locale';
 import { resolveThemeToProps, ThemeContext, ThemeContextValue } from './theme';
 
@@ -18,19 +18,32 @@ export interface ConfigsProviderProps {
   children: ReactNode | ((props: ConfigsProviderRenderProps) => ReactNode);
 }
 
-function ConfigsProvider({ theme, locale = enUS, children }: ConfigsProviderProps) {
+/**
+ * Provide theme / locale configs.
+ *
+ * Omitted configs are inherited from the closest ancestor `ConfigsProvider`
+ * (falling back to the context defaults, e.g. `enUS`, at the top level), so
+ * components which render their own nested `ConfigsProvider` (e.g.
+ * `<Quadrats>`) won't reset configs provided by the host application.
+ */
+function ConfigsProvider({ theme, locale, children }: ConfigsProviderProps) {
+  const inheritedTheme = useContext(ThemeContext);
+  const inheritedLocale = useContext(LocaleContext);
+  const resolvedLocale = locale ?? inheritedLocale;
   const themeContext: ThemeContextValue = useMemo(
-    () => ({
-      props: theme ? resolveThemeToProps(theme) : {},
-      theme,
-    }),
-    [theme],
+    () => (theme
+      ? {
+        props: resolveThemeToProps(theme),
+        theme,
+      }
+      : inheritedTheme),
+    [theme, inheritedTheme],
   );
 
   return (
     <ThemeContext.Provider value={themeContext}>
-      <LocaleContext.Provider value={locale}>
-        {typeof children === 'function' ? children({ theme: themeContext, locale }) : children}
+      <LocaleContext.Provider value={resolvedLocale}>
+        {typeof children === 'function' ? children({ theme: themeContext, locale: resolvedLocale }) : children}
       </LocaleContext.Provider>
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
# fix(configs): inherit ancestor configs in nested ConfigsProvider

> Branch: `fix/q4-configs-provider-inherit`（commit `893b1e7`）
> 影響套件：`@quadrats/react`（configs）

## 問題

`<Quadrats>` 內部會自己 render 一層 `ConfigsProvider`。而 `ConfigsProvider` 對沒傳的 prop 一律套硬預設（`locale = enUS`、theme = 空）——所以 host app 在外層 `ConfigsProvider` 設好的 `theme`/`locale`，會被 `<Quadrats>` 的內層 provider **整組蓋掉重設**。實際病徵：繁中後台的連結輸入框 placeholder 變英文（"Paste or type a link…"），除非把 theme/locale **再傳一次**給 `<Quadrats>`。

## 重現

```tsx
<ConfigsProvider locale={zhTW} theme="qdr">
  <Quadrats editor={editor} value={value} onChange={onChange}>
    {/* 任何用 useLocale() 的內部 UI（如 link toolbar input） */}
  </Quadrats>
</ConfigsProvider>
// → useLocale() 取得 enUS，不是 zhTW
```

Downstream apps were forced to pass theme/locale twice as a workaround：`theme/locale` 同時傳 `<ConfigsProvider>` 與 `<Quadrats>`（內層 ConfigsProvider 預設 enUS，必須傳才不被蓋）。

## 根因

`packages/react/configs/src/ConfigsProvider.tsx`：

- `function ConfigsProvider({ theme, locale = enUS, children })` —— 預設值在 **provider 層**寫死，而不是讓 context default 處理；巢狀時就把祖先值蓋掉。
- theme 同病：`props: theme ? resolveThemeToProps(theme) : {}` —— 沒傳 theme 就重設為空。

## 修法（diff 摘要）

沒傳的 prop 改成**讀最近祖先 context 值**；頂層行為不變（無祖先時 context default 仍是 `enUS`／空 theme props）；巢狀 provider 顯式傳值仍優先。

```diff
-function ConfigsProvider({ theme, locale = enUS, children }: ConfigsProviderProps) {
+function ConfigsProvider({ theme, locale, children }: ConfigsProviderProps) {
+  const inheritedTheme = useContext(ThemeContext);
+  const inheritedLocale = useContext(LocaleContext);
+  const resolvedLocale = locale ?? inheritedLocale;
   const themeContext: ThemeContextValue = useMemo(
-    () => ({ props: theme ? resolveThemeToProps(theme) : {}, theme }),
-    [theme],
+    () => (theme ? { props: resolveThemeToProps(theme), theme } : inheritedTheme),
+    [theme, inheritedTheme],
   );
```

## 影響面

- 頂層單一 ConfigsProvider：行為零變化（spec 有 baseline 案驗證）。
- 巢狀（`<Quadrats>` 場景）：外層設定不再被重設 → 下游可移除「theme/locale 要傳兩次」的 workaround。
- theme 與 locale 同一個坑的兩個面向，一起修（同一 PR 合理範圍）。
- 邊角：theme 未傳時沿用祖先 context 物件 reference，`useMemo` 依賴正確、不多 re-render。

## 驗證證據

- **新 spec `ConfigsProvider.spec.tsx` 4 案**（react-dom/client + React.act，零新增依賴）：
  - red→green 證明：把修正 stash 回 main 版實作 → 「inherit locale」「inherit theme」2 案**紅**；套修正 → 4 案全綠。
  - 「top level 預設 enUS」「巢狀顯式傳值優先」2 案在新舊實作都綠 ＝ 行為不回歸。
- **全 repo jest**：47 passed / 7 failed——失敗全部是 main 先天紅的 2 個 blockquote suite（基線 43 passed / 同樣 7 failed），無新增退化。
- **eslint** 過；**真實建置管線** `packages/react` `npm run build` exit 0。
- 實戰場：hit in zh-TW production apps（連結輸入框 placeholder 變英文）；修正後已回驗「`<Quadrats>` 沒直接收 theme/locale」情境。

## 備註

- 一坑一 PR：只動 ConfigsProvider 解析邏輯，不動 `<Quadrats>`、不動 locale 內容。
