### PR TITLE
fix(highlight): ship default styles for highlight marks

### DIFF
--- a/packages/react/highlight/package.json
+++ b/packages/react/highlight/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@quadrats/react/highlight",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss"
+  ],
   "quadratsConfig": {
     "deps": [
       "toggle-mark"
-    ]
+    ],
+    "styles": {
+      "highlight": "highlight"
+    }
   }
 }

--- a/packages/react/highlight/src/highlight.scss
+++ b/packages/react/highlight/src/highlight.scss
@@ -1,0 +1,19 @@
+/**
+ * Default styling for highlight marks.
+ *
+ * `defaultRenderHighlight` renders `<mark class="highlight">`
+ * (or `highlight.<variant>` for custom variants) in both the editor and the
+ * jsx-serializer output, but no stylesheet was shipped for it, so the
+ * highlight was only visible through the browser's default `mark` style —
+ * and variant classes (`highlight.<variant>`) got no styling at all.
+ *
+ * Override via the `--qdr-highlight-bg` / `--qdr-highlight-text` custom
+ * properties, or per variant with `mark[class='highlight.<variant>']`.
+ */
+mark.highlight,
+mark[class^='highlight.'],
+.qdr-editable mark,
+.qdr-content mark {
+  background-color: var(--qdr-highlight-bg, #fef08a);
+  color: var(--qdr-highlight-text, inherit);
+}


### PR DESCRIPTION
# fix(highlight): ship default styles for highlight marks

> Branch: `fix/q5-highlight-mark-style`（commit `d596b46`）
> 影響套件：`@quadrats/react`（highlight 子套件，新增發佈檔 `highlight/highlight.{css,scss}`）

## 問題

highlight（螢光標記）在編輯器和前台序列化輸出都 render `<mark class="highlight">`（自訂 variant 時是 `class="highlight.<variant>"`），但套件**完全沒附任何樣式**：

- 前台只能靠瀏覽器預設 `mark`（黃底）；常見 CSS reset／normalize 一清掉 `mark` 預設、或深色主題下，螢光就**看不見**。
- variant class `highlight.<variant>` 是帶點的 class token，`.highlight` selector 根本選不到 → variant 永遠無樣式。

## 重現

1. CMS 編輯器套 highlight → 前台（jsx-serializer 輸出）`<mark class="highlight">`。
2. 站台 globals.css 有 reset（或未載任何 mark 規則）→ 螢光段落與一般文字無任何視覺差異。

下游 app 被迫自補的 workaround：jsx-serializer 吐 `<mark class="highlight">`，站台 globals.css 無 `mark` 規則 → 螢光看不出來，只能自行補 `.qdr-content mark{...}` 規則。

## 根因

`packages/react/highlight/` 沒有 scss、`package.json` 無 `quadratsConfig.styles` 條目——其他視覺性子套件（toolbar、paragraph、heading…）都有隨包樣式，highlight 漏了。

## 修法（diff 摘要）

- 新增 `packages/react/highlight/src/highlight.scss`：

```scss
mark.highlight,
mark[class^='highlight.'],   // 帶點 variant class 的唯一可選法
.qdr-editable mark,          // 編輯器內
.qdr-content mark {          // 前台內容容器（serializer 輸出建議包這層）
  background-color: var(--qdr-highlight-bg, #fef08a);
  color: var(--qdr-highlight-text, inherit);
}
```

- `packages/react/highlight/package.json`：加 `quadratsConfig.styles {"highlight": "highlight"}`（走既有建置管線發佈 `highlight.css`）＋ `sideEffects` 改成與其他帶樣式子套件一致的 `["**/*.css","**/*.scss"]`（防 tree-shake 把樣式抖掉）。

使用方式（opt-in，與 toolbar.css 同模式）：

```ts
import '@quadrats/react/highlight/highlight.css';
```

## 影響面

- 新增發佈檔，**不影響未 import 的使用者**（opt-in stylesheet，零 breaking）。
- 顏色可用 `--qdr-highlight-bg` / `--qdr-highlight-text` 覆寫；variant 可用 `mark[class='highlight.<variant>']` 各自上色。
- 確立 `.qdr-content` 作為前台序列化內容容器的官方 class 慣例（already adopted by downstream integrations）。
- 下游可移除的 workaround：各下游 app globals.css 自補的 `.qdr-content mark` 規則。

## 驗證證據

- `npx stylelint packages/react/highlight/src/highlight.scss` 通過。
- **真實建置管線** `packages/react` `npm run build` exit 0；dist 產出 `highlight/highlight.css`（內容見上）＋ `highlight/highlight.scss`，dist package.json `sideEffects` 正確帶出。
- 規則內容 equivalent to the workaround rule downstream apps had to add to globals.css（`.qdr-content mark{ background:#fef08a }`），且補上 variant 與編輯器內兩個情境。

## 備註

- 一坑一 PR：只補 highlight 樣式發佈，不動 `defaultRenderHighlight` 的 class 命名（帶點 class 的命名問題可另議——改名是 markup contract 變更，影響既有存檔內容的 CSS，不混入本 PR）。
