### PR TITLE
docs(toolbar): document the two-toolbar pattern for the selection bubble

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ Currently based on [Slate](https://github.com/ianstormtaylor/slate) framework.
 - Default
 - Dark Mode
 
+## Toolbar usage
+
+`<Toolbar>` has two render modes, and a typical editor renders **both**
+instances side by side:
+
+```tsx
+<Quadrats editor={editor} value={value} onChange={setValue}>
+  {/* Main toolbar: always-visible sticky bar above the editable area. */}
+  <Toolbar fixed>{renderTools}</Toolbar>
+  {/* Selection bubble: floats above the text whenever the selection is
+      expanded. Without this second instance, selecting text shows no
+      bubble at all — a fixed toolbar never floats. */}
+  <Toolbar onlyRenderExpanded>{renderTools}</Toolbar>
+  <Editable renderElement={renderElement} renderLeaf={renderLeaf} />
+</Quadrats>
+```
+
+- `fixed` — render as the main toolbar (sticky, always visible).
+- `onlyRenderExpanded` — render only when the selection is expanded, as a
+  floating bubble positioned at the selection.
+- The `children` render prop receives an `expanded` flag, so the same
+  renderer can show different tools in the bar and in the bubble.
+
 ## Development scripts
 
 Useful scripts include:

--- a/packages/react/toolbar/src/components/Toolbar.tsx
+++ b/packages/react/toolbar/src/components/Toolbar.tsx
@@ -54,11 +54,24 @@ export interface ToolbarProps {
    */
   containerRef?: React.MutableRefObject<HTMLElement | undefined>;
   /**
-   * only render expanded case toolbar or not.
+   * Only render the toolbar when the selection is expanded (the floating
+   * "selection bubble" shown above selected text).
+   *
+   * Note that a `<Toolbar fixed>` never floats: to get the selection bubble
+   * you must render a second toolbar instance alongside the fixed one —
+   * without it, selecting text shows no bubble at all.
+   *
+   * ```tsx
+   * <Toolbar fixed>{renderTools}</Toolbar>
+   * <Toolbar onlyRenderExpanded>{renderTools}</Toolbar>
+   * <Editable ... />
+   * ```
    */
   onlyRenderExpanded?: boolean;
   /**
-   * fix main toolbar or not.
+   * Render as the main toolbar: a sticky bar above the editable area which is
+   * always visible, instead of a floating toolbar positioned at the
+   * selection. See `onlyRenderExpanded` for the companion selection bubble.
    */
   fixed?: boolean;
 }


### PR DESCRIPTION
# docs(toolbar): document the two-toolbar pattern for the selection bubble

> Branch: `docs/q6-expanded-toolbar`（commit `a5a1f28`）
> 影響範圍：README.md ＋ `ToolbarProps` JSDoc（純文件，無行為變更）

## 問題

選字浮動工具列（selection bubble）需要在 `<Toolbar fixed>` 之外**另外 render 一個** `<Toolbar onlyRenderExpanded>` 實例——`fixed` toolbar 永遠不會浮動。這個 pattern 只存在於 storybook playground 原始碼裡（`Playground.stories.tsx`：兩個 `<Toolbar>` 並排），README 與 JSDoc 都沒寫：

- `onlyRenderExpanded` 的 JSDoc 原文只有一行 "only render expanded case toolbar or not."
- `fixed` 原文只有 "fix main toolbar or not."

整合者只放一個 `<Toolbar fixed>` → 選字沒有 bubble、也沒有任何提示為什麼。

## 重現

RichEditor 只 render `<Toolbar fixed>`（無第二個 `<Toolbar onlyRenderExpanded>`）→ 選取文字 → 無浮動工具列、console 無警告。（Observed in a downstream integration: a single fixed Toolbar, no bubble, no hint.）

## 根因

文件缺口（doc drift）：唯一的 API 文件（JSDoc）沒有說明兩個 render mode 的關係，root README 沒有任何 toolbar 使用說明。

## 修法（diff 摘要）

- **README.md**：新增「Toolbar usage」一節，含雙 toolbar 完整範例（fixed 主列 + onlyRenderExpanded 選字 bubble + Editable）與三點說明（`fixed`／`onlyRenderExpanded`／children render prop 的 `expanded` flag）。
- **Toolbar.tsx JSDoc**：`onlyRenderExpanded` 改為完整說明＋inline 範例（明示「沒有第二個實例就沒有 bubble」）；`fixed` 改為說明 sticky 主列行為並互相參照。

## 影響面

- 純文件（README＋註解），零執行期行為變更；TS 使用者 hover prop 即可看到 pattern。
- runtime dev warning 評估過不可行：單一 `<Toolbar fixed>` 是合法配置（有人就是不要 bubble），元件層無法可靠判定「缺第二個實例」是 bug 還是刻意，硬加警告會誤報——故落在文件層。

## 驗證證據

- `npx eslint packages/react/toolbar/src/components/Toolbar.tsx` 過（JSDoc 不破壞 lint）。
- **真實建置管線** `packages/react` `npm run build` exit 0（JSDoc 變更不影響建置與 dts 產出）。
- README 範例與 storybook playground 的實際用法（`Playground.stories.tsx` 雙 `<Toolbar>`）一致。
- 實戰場：a downstream app（選字無 bubble 病徵）；merge 後該 app 依文件補第二個 Toolbar 即解。

## 備註

- 一坑一 PR：只補文件，不動 Toolbar 邏輯（toolbar 高度問題另以獨立 PR 處理）。
