### PR TITLE
docs: note that paragraph renders via createRenderParagraphElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,35 @@ Currently based on [Slate](https://github.com/ianstormtaylor/slate) framework.
 - Default
 - Dark Mode
 
+## Rendering paragraphs (1.x note)
+
+Unlike most other plugins, the paragraph controller returned by
+`createReactParagraph()` does **not** expose a `createRenderElement()`
+method. Older examples in the wild that call it throw at runtime:
+
+```ts
+const paragraph = createReactParagraph();
+
+paragraph.createRenderElement();
+// ✗ TypeError: paragraph.createRenderElement is not a function
+```
+
+Use the standalone `createRenderParagraphElement()` exported from
+`@quadrats/react/paragraph` instead:
+
+```tsx
+import { createReactParagraph, createRenderParagraphElement } from '@quadrats/react/paragraph';
+
+const paragraph = createReactParagraph();
+
+const renderElement = composeRenderElements([
+  createRenderParagraphElement(),
+  // other plugins keep the controller method form:
+  heading.createRenderElement(),
+  list.createRenderElement(),
+]);
+```
+
 ## Development scripts
 
 Useful scripts include:


### PR DESCRIPTION
# docs: note that paragraph renders via createRenderParagraphElement

> Branch: `docs/q7-paragraph-render-doc`（commit `a304405`）
> 影響範圍：README.md（純文件，無行為變更）

## 問題

文件漂移：older examples in circulation 寫 `paragraph.createRenderElement()`，但 1.1.x 的 `createReactParagraph()` 回傳的 controller **沒有** `createRenderElement` 方法——跑起來直接 throw：

```
TypeError: paragraph.createRenderElement is not a function
```

正確 API 是獨立函式 `createRenderParagraphElement()`（`@quadrats/react/paragraph` export），但 README 完全沒提，整合者只能去翻 storybook 原始碼。

## 重現

```ts
import { createReactParagraph } from '@quadrats/react/paragraph';

const paragraph = createReactParagraph();
paragraph.createRenderElement(); // ✗ TypeError
```

安裝版 paragraph plugin 無 `createRenderElement` 方法，`createRenderParagraphElement()` 是唯一可行且語意等價的寫法——every downstream integration has to rediscover this independently。

## 根因

- 源碼事實：`packages/react/paragraph/src/createReactParagraph.ts` 只回傳 `{...core}`（common Paragraph），不含 render 方法；render 走獨立的 `createRenderParagraphElement()`（`createRenderElement({ type: PARAGRAPH_TYPE, render })` 的封裝）。
- 其他 plugin（heading/list/link/…）都是 controller method 形式 `xxx.createRenderElement()`——paragraph 是唯一例外，且無文件說明 → 漂移。

## 修法（diff 摘要）

README 新增「Rendering paragraphs (1.x note)」一節：

- 明示錯誤寫法與 runtime error 訊息（讓搜錯誤訊息的人能 Google 到）。
- 正確寫法完整範例：`createRenderParagraphElement()` ＋ `composeRenderElements([...])` 與其他 plugin 的 controller method 形式並列（範例與 storybook playground 實際用法一致，`composeRenderElements`、`createRenderParagraphElement` 皆為現行 public export，已核實）。

## 影響面

- 純 README 文件，零執行期變更、零 API 變更。
- 替代方案評估：在 paragraph controller 補一個 `createRenderElement` alias 可「修 API 一致性」，但那是 API 設計變更（且 read-more 等 plugin 的 controller method 簽名不一，貿然對齊有兼容風險）→ 文件先行，API 對齊可另開 issue 討論。

## 驗證證據

- 源碼核實：`createReactParagraph()` 回傳值無 `createRenderElement`（`packages/react/paragraph/src/createReactParagraph.ts`）；`createRenderParagraphElement` / `composeRenderElements` 均為現行 export（`packages/react/paragraph/src/index.ts`、`packages/react/src/core/index.ts:35`）。
- README 範例比照 `stories/components/Playground.stories.tsx`（line 439/528 實際呼叫）。
- 實戰場：多個 downstream integrations 整合時都踩過此漂移。

## 備註

- 一坑一 PR：只補文件；不在本 PR 動 paragraph API。
